### PR TITLE
Give BokehKernel its own _instance attribute

### DIFF
--- a/ipywidgets_bokeh/kernel.py
+++ b/ipywidgets_bokeh/kernel.py
@@ -57,6 +57,8 @@ class BokehKernel(ipykernel.kernelbase.Kernel):
     implementation_version = '0.1.2'
     banner = 'banner'
 
+    _instance = None
+
     def __init__(self):
         super(BokehKernel, self).__init__()
 


### PR DESCRIPTION
So apparently you can only create one unique instance of `ipykernel.kernelbase.Kernel` classes by default. We can override this by giving the BokehKernel it's own `_instance` attribute. Without this you will get the following error:

```
~/miniconda3/envs/bokeh2.0/lib/python3.8/site-packages/traitlets/config/configurable.py in instance(cls, *args, **kwargs)
    419             return cls._instance
    420         else:
--> 421             raise MultipleInstanceError(
    422                 'Multiple incompatible subclass instances of '
    423                 '%s are being created.' % cls.__name__

MultipleInstanceError: Multiple incompatible subclass instances of BokehKernel are being created.
```