### PR TITLE
Allow multiple kernels

### DIFF
--- a/ipywidgets_bokeh/widget.py
+++ b/ipywidgets_bokeh/widget.py
@@ -22,6 +22,7 @@ class IPyWidget(HTMLBox):
 
     def __init__(self, *, widget: Widget, **kwargs):
         super().__init__(**kwargs)
+        self._widget = widget
         spec = widget.get_view_spec()
         state = Widget.get_manager_state(widgets=[])
         state["state"] = embed.dependency_state([widget], drop_defaults=True)


### PR DESCRIPTION
This PR allows creating multiple kernel instances which can be used to sync ipywidgets embedded in a notebook. This seeems to work well overall and does not interfere with the usual server based usage which uses a single Kernel in all cases.

See https://github.com/holoviz/panel/pull/1285 for an implementation that uses this.