### PR TITLE
Allow setting CDN from kwargs, by instance, or by class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /dist/
 /*.egg-info/
 __pycache__/
-yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dist/
 /*.egg-info/
+__pycache__/
+yarn.lock

--- a/ipywidgets_bokeh/src/loader.ts
+++ b/ipywidgets_bokeh/src/loader.ts
@@ -9,9 +9,7 @@ function require_promise(pkg: string | string[]): Promise<any> {
   return new Promise((resolve, reject) => requirejs(pkg, resolve, reject))
 }
 
-const cdn = 'https://unpkg.com'
-
-function get_cdn_url(moduleName: string, moduleVersion: string) {
+function get_cdn_url(moduleName: string, moduleVersion: string, cdn: string) {
   let packageName = moduleName
   let fileName = 'index' // default filename
   // if a '/' is present, like 'foo/bar', packageName is changed to 'foo', and path to 'bar'
@@ -32,13 +30,15 @@ function get_cdn_url(moduleName: string, moduleVersion: string) {
 
 const mods = new Set()
 
-export function require_loader(moduleName: string, moduleVersion: string): Promise<any> {
-  if (!mods.has(moduleName)) {
-    mods.add(moduleName)
-    const conf: {paths: {[key: string]: string}} = {paths: {}}
-    conf.paths[moduleName] = get_cdn_url(moduleName, moduleVersion)
-    _requirejs.config(conf)
+export function generate_require_loader(cdn: string): any {
+  return function require_loader(moduleName: string, moduleVersion: string): Promise<any> {
+    if (!mods.has(moduleName)) {
+      mods.add(moduleName)
+      const conf: {paths: {[key: string]: string}} = {paths: {}}
+      conf.paths[moduleName] = get_cdn_url(moduleName, moduleVersion, cdn)
+      _requirejs.config(conf)
+    }
+    console.debug(`Loading ${moduleName}@${moduleVersion} from ${cdn}`)
+    return require_promise([moduleName])
   }
-  console.debug(`Loading ${moduleName}@${moduleVersion} from ${cdn}`)
-  return require_promise([moduleName])
 }

--- a/ipywidgets_bokeh/src/widget.ts
+++ b/ipywidgets_bokeh/src/widget.ts
@@ -4,7 +4,7 @@ import {MessageSentEvent} from "@bokehjs/document/events"
 import * as p from "@bokehjs/core/properties"
 import {isString} from "@bokehjs/core/util/types"
 
-import {require_loader} from "./loader"
+import {generate_require_loader} from "./loader"
 import {WidgetManager, ModelBundle} from "./manager"
 
 const widget_managers: WeakMap<Document, WidgetManager> = new WeakMap()
@@ -40,6 +40,7 @@ export namespace IPyWidget {
 
   export type Props = HTMLBox.Props & {
     bundle: p.Property<ModelBundle>
+    cdn: p.Property<string>
   }
 }
 
@@ -50,6 +51,7 @@ export class IPyWidget extends HTMLBox {
 
   constructor(attrs?: Partial<IPyWidget.Attrs>) {
     super(attrs)
+    console.log({cdn: this.properties.cdn.get_value()})
   }
 
   static __name__ = "IPyWidget"
@@ -60,6 +62,7 @@ export class IPyWidget extends HTMLBox {
 
     this.define<IPyWidget.Props>({
       bundle: [ p.Any ],
+      cdn: [ p.String ],
     })
   }
 
@@ -67,7 +70,9 @@ export class IPyWidget extends HTMLBox {
     const doc = this.document!
 
     if (!widget_managers.has(doc)) {
-      const manager = new WidgetManager({loader: require_loader})
+      const manager = new WidgetManager({
+        loader: generate_require_loader(this.properties.cdn.get_value())
+      })
       widget_managers.set(doc, manager)
 
       manager.bk_open((data: string | ArrayBuffer): void => {

--- a/ipywidgets_bokeh/src/widget.ts
+++ b/ipywidgets_bokeh/src/widget.ts
@@ -51,7 +51,6 @@ export class IPyWidget extends HTMLBox {
 
   constructor(attrs?: Partial<IPyWidget.Attrs>) {
     super(attrs)
-    console.log({cdn: this.properties.cdn.get_value()})
   }
 
   static __name__ = "IPyWidget"
@@ -62,7 +61,7 @@ export class IPyWidget extends HTMLBox {
 
     this.define<IPyWidget.Props>({
       bundle: [ p.Any ],
-      cdn: [ p.String ],
+      cdn: [ p.String, "https://unpkg.com" ],
     })
   }
 
@@ -71,7 +70,7 @@ export class IPyWidget extends HTMLBox {
 
     if (!widget_managers.has(doc)) {
       const manager = new WidgetManager({
-        loader: generate_require_loader(this.properties.cdn.get_value())
+        loader: generate_require_loader(this.cdn),
       })
       widget_managers.set(doc, manager)
 

--- a/ipywidgets_bokeh/webpack.config.js
+++ b/ipywidgets_bokeh/webpack.config.js
@@ -13,7 +13,7 @@ const rules = [
 
 module.exports = (env={}, argv={}) => {
   const mode = argv.mode ?? "production"
-  const minimize = mode == "production"
+  const minimize = mode === "production"
   return {
     entry: ["./dist/lib/index.js"],
     output: {

--- a/ipywidgets_bokeh/widget.py
+++ b/ipywidgets_bokeh/widget.py
@@ -5,24 +5,42 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from bokeh.core.properties import Any
+from bokeh.core.properties import Any, String
 from bokeh.models.layouts import HTMLBox
 
 from ipywidgets import embed, Widget
 
-from .kernel import kernel
 
 class IPyWidget(HTMLBox):
+    """Wrap an IPyWidget for embedding in a bokeh app.
+
+    Parameters
+    ----------
+    widget : Widget
+        ipywidget to wrap for embedding in a bokeh app
+    **kwargs
+        All kwargs are passed to bokeh.model.Model except 'cdn', if present.
+
+        The CDN for external JS resources uses the 'cdn' kwarg if set; otherwise use
+        self.default_cdn. After initialization (but before rendering), the CDN can be
+        set using IPyWidget.set_cdn; see below.
+
+    """
 
     __javascript__ = [
         "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js",
     ]
 
     bundle = Any()
+    cdn = String()
+    default_cdn = 'https://unpkg.com'
 
     def __init__(self, *, widget: Widget, **kwargs):
+        cdn = kwargs.pop('cdn', self.default_cdn)
+
         super().__init__(**kwargs)
         spec = widget.get_view_spec()
         state = Widget.get_manager_state(widgets=[])
         state["state"] = embed.dependency_state([widget], drop_defaults=True)
-        self.bundle = dict(spec=spec, state=state)
+        self.bundle = {'spec': spec, 'state': state}
+        self.cdn = cdn

--- a/ipywidgets_bokeh/widget.py
+++ b/ipywidgets_bokeh/widget.py
@@ -37,4 +37,4 @@ class IPyWidget(HTMLBox):
         spec = widget.get_view_spec()
         state = Widget.get_manager_state(widgets=[])
         state["state"] = embed.dependency_state([widget], drop_defaults=True)
-        self.bundle = {'spec': spec, 'state': state}
+        self.bundle = dict(spec=spec, state=state)

--- a/ipywidgets_bokeh/widget.py
+++ b/ipywidgets_bokeh/widget.py
@@ -10,6 +10,7 @@ from bokeh.models.layouts import HTMLBox
 
 from ipywidgets import embed, Widget
 
+from .kernel import kernel
 
 class IPyWidget(HTMLBox):
     """Wrap an IPyWidget for embedding in a bokeh app.

--- a/ipywidgets_bokeh/widget.py
+++ b/ipywidgets_bokeh/widget.py
@@ -18,12 +18,9 @@ class IPyWidget(HTMLBox):
     ----------
     widget : Widget
         ipywidget to wrap for embedding in a bokeh app
+    cdn : str
+        The CDN for external JS resources.
     **kwargs
-        All kwargs are passed to bokeh.model.Model except 'cdn', if present.
-
-        The CDN for external JS resources uses the 'cdn' kwarg if set; otherwise use
-        self.default_cdn. After initialization (but before rendering), the CDN can be
-        set using IPyWidget.set_cdn; see below.
 
     """
 
@@ -32,15 +29,11 @@ class IPyWidget(HTMLBox):
     ]
 
     bundle = Any()
-    cdn = String()
-    default_cdn = 'https://unpkg.com'
+    cdn = String(default="https://unpkg.com")
 
     def __init__(self, *, widget: Widget, **kwargs):
-        cdn = kwargs.pop('cdn', self.default_cdn)
-
         super().__init__(**kwargs)
         spec = widget.get_view_spec()
         state = Widget.get_manager_state(widgets=[])
         state["state"] = embed.dependency_state([widget], drop_defaults=True)
         self.bundle = {'spec': spec, 'state': state}
-        self.cdn = cdn


### PR DESCRIPTION
## Summary

This PR adds support for customizing the CDN, closing #57:

1. Pass in a `cdn` kwarg to `IPyWidget` during instantiation: `IPyWidget(widget=widget, cdn='https://any-custom-cdn-here')`. This takes highest precedence.
2. If no `cdn` kwarg is given, `IPyWidget.default_cdn` is used. By default this is set to https://unpkg.com to match current functionality. The default CDN can be set by calling `IPyWidget.set_default_cdn` before any `IPyWidget` instances are created.
3. You can also set the CDN on an individual instance by calling `IPyWidget.set_cdn`.

I've also made a small modification to the webpack config where a `==` should be `===`.