### PR TITLE
Trigger layout invalidation on widget display

### DIFF
--- a/ipywidgets_bokeh/src/manager.ts
+++ b/ipywidgets_bokeh/src/manager.ts
@@ -162,7 +162,7 @@ export class WidgetManager extends HTMLManager {
     model.comm_live = true
   }
 
-  async render(bundle: ModelBundle, el: HTMLElement): Promise<WidgetView | null> {
+  async render(bundle: ModelBundle, el: HTMLElement, onDisplay: () => void): Promise<WidgetView | null> {
     const {spec, state} = bundle
     const new_models = state.state
     for (const [id, new_model] of entries(new_models)) {
@@ -190,6 +190,7 @@ export class WidgetManager extends HTMLManager {
       }
 
       const view = await this.create_view(model, {el})
+      view.on('displayed', onDisplay)
       await this.display_view(view, el)
       return view
     } finally {

--- a/ipywidgets_bokeh/src/manager.ts
+++ b/ipywidgets_bokeh/src/manager.ts
@@ -190,7 +190,7 @@ export class WidgetManager extends HTMLManager {
       }
 
       const view = await this.create_view(model, {el})
-      view.on('displayed', onDisplay)
+      view.on("displayed", onDisplay)
       await this.display_view(view, el)
       return view
     } finally {

--- a/ipywidgets_bokeh/src/widget.ts
+++ b/ipywidgets_bokeh/src/widget.ts
@@ -86,7 +86,7 @@ export class IPyWidgetView extends LayoutDOMView {
       const manager = widget_managers.get(document)
       assert(manager != null, "manager is null")
 
-      this.ipy_view = await manager.render(this.model.bundle, this.container)
+      this.ipy_view = await manager.render(this.model.bundle, this.container, () => this.invalidate_layout())
     } else {
       this.container.append(this.ipy_view.el)
     }

--- a/ipywidgets_bokeh/webpack.config.js
+++ b/ipywidgets_bokeh/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = (env={}, argv={}) => {
       }
     ],
     module: {rules},
-    devtool: minimize ? false : "source-map",
+    devtool: mode === "development" ? 'inline-source-map' : false,
     mode,
     optimization: {minimize},
   }


### PR DESCRIPTION
## Summary

This PR triggers layout invalidation when the widget is displayed, closing #58. See that issue for a complete discussion and examples.

## Changes

- This change modifies how ipywidgets are displayed by allowing an `onDisplay` callback to be passed to the `WidgetManager.render` function which triggers when the view's `displayed` event is emitted.
- Back in the `IPyWidgetView`, the widget manager's `render` function is passed a callback which invalidates the layout.
- Also modified the "dev" mode script to avoid minimizing the bundle, making debugging easier.