### PR TITLE
Unpin upper pin of bokeh for local install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,9 @@ class BuildJS(Command):
         finally:
             os.chdir("..")
 
+
 install_requires = [
-    "bokeh >=2.4.0,<2.5",
+    "bokeh >=2.4.0",
     "ipywidgets >=7.5.0",
 ]
 


### PR DESCRIPTION
I want to test out the updates in https://github.com/bokeh/ipywidgets_bokeh/pull/51.

But when I `pip install "git+https://github.com/bokeh/ipywidgets_bokeh.git"` it downgrades my bokeh to 2.4.

(I assume the next release will support 3.0, I don't know if it will still support Bokeh 2.4) 