### PR TITLE
Add ad-hoc support for shadow DOM to ipywidgets

### DIFF
--- a/examples/ipyvolume_camera.py
+++ b/examples/ipyvolume_camera.py
@@ -47,44 +47,68 @@ ip_randomize.on_click(randomize)
 
 ip_vbox = ipw.VBox([ip_x, ip_y, ip_z, ip_randomize])
 
-def change_anglex(change):
-    bk_x.value = round(np.degrees(change["new"]))
-def change_angley(change):
-    bk_y.value = round(np.degrees(change["new"]))
-def change_anglez(change):
-    bk_z.value = round(np.degrees(change["new"]))
-ipv_plot.observe(change_anglex, names="anglex")
-ipv_plot.observe(change_angley, names="angley")
-ipv_plot.observe(change_anglez, names="anglez")
+def change_angle_x(change):
+    new = change["new"]
+    print(f"change_angle_x: new={new}")
+    bk_x.value = round(np.degrees(new))
+
+def change_angle_y(change):
+    new = change["new"]
+    print(f"change_angle_y: new={new}")
+    bk_y.value = round(np.degrees(new))
+
+def change_angle_z(change):
+    new = change["new"]
+    print(f"change_angle_z: new={new}")
+    bk_z.value = round(np.degrees(new))
+
+ipv_plot.observe(change_angle_x, names="anglex")
+ipv_plot.observe(change_angle_y, names="angley")
+ipv_plot.observe(change_angle_z, names="anglez")
 
 def change_bk_x(_attr, _old, new):
+    print(f"change_bk_x: new={new}")
     ip_x.value = new
     ipv_plot.anglex = np.radians(new)
     source.patch(dict(angles=[(0, new)]))
+
 def change_bk_y(_attr, _old, new):
+    print(f"change_bk_y: new={new}")
     ip_y.value = new
     ipv_plot.angley = np.radians(new)
     source.patch(dict(angles=[(1, new)]))
+
 def change_bk_z(_attr, _old, new):
+    print(f"change_bk_z: new={new}")
     ip_z.value = new
     ipv_plot.anglez = np.radians(new)
     source.patch(dict(angles=[(2, new)]))
+
 bk_x.on_change("value", change_bk_x)
 bk_y.on_change("value", change_bk_y)
 bk_z.on_change("value", change_bk_z)
 
 def change_ip_x(change):
-    bk_x.value = change["new"]
+    new = change["new"]
+    print(f"change_ip_x: new={new}")
+    bk_x.value = new
+
 def change_ip_y(change):
-    bk_y.value = change["new"]
+    new = change["new"]
+    print(f"change_ip_y: new={new}")
+    bk_y.value = new
+
 def change_ip_z(change):
-    bk_z.value = change["new"]
+    new = change["new"]
+    print(f"change_ip_z: new={new}")
+    bk_z.value = new
+
 ip_x.observe(change_ip_x, names="value")
 ip_y.observe(change_ip_y, names="value")
 ip_z.observe(change_ip_z, names="value")
 
 bk_hbox = row([bk_vbox, bk_plot])
-ip_hbox = ipw.HBox([ip_vbox, ipv_plot])
+ip_hbox = ipw.VBox([ip_vbox, ipv_plot])
 
 wrapper = IPyWidget(widget=ip_hbox, width=800, height=300)
 layout = column([bk_hbox, wrapper])

--- a/ipywidgets_bokeh/webpack.config.js
+++ b/ipywidgets_bokeh/webpack.config.js
@@ -5,9 +5,9 @@ const style_loader = {
   loader: "style-loader",
   options: {
     injectType: "lazyStyleTag",
-    insert: function insertIntoTarget(element, options) {
-      const target = options.target ?? document.head
-      target.append(element)
+    insert: (element, options) => {},
+    styleTagTransform: (css, style, options) => {
+      options.handler(css)
     },
   },
 }

--- a/ipywidgets_bokeh/webpack.config.js
+++ b/ipywidgets_bokeh/webpack.config.js
@@ -1,8 +1,19 @@
 const path = require("path");
 const version = require('./package.json').version;
 
+const style_loader = {
+  loader: "style-loader",
+  options: {
+    injectType: "lazyStyleTag",
+    insert: function insertIntoTarget(element, options) {
+      const target = options.target ?? document.head
+      target.append(element)
+    },
+  },
+}
+
 const rules = [
-  { test: /\.css$/, use: ["style-loader", "css-loader"]},
+  { test: /\.css$/, use: [style_loader, "css-loader"] },
   // required to load font-awesome
   { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: "url-loader?limit=10000&mimetype=application/font-woff" },
   { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: "url-loader?limit=10000&mimetype=application/font-woff" },
@@ -34,7 +45,7 @@ module.exports = (env={}, argv={}) => {
       }
     ],
     module: {rules},
-    devtool: false,
+    devtool: minimize ? false : "source-map",
     mode,
     optimization: {minimize},
   }


### PR DESCRIPTION
Works for ipywidgets bundled with `ipywigets_bokeh` bundle. Thirdparty ipywidgets have to handled separately.
![image](https://user-images.githubusercontent.com/27475/231911484-ff7b4c21-7873-49a3-9a57-bd9f5b05e754.png)
