### PR TITLE
Use a simpler but more effective shadow DOM workaround

### DIFF
--- a/ipywidgets_bokeh/src/widget.ts
+++ b/ipywidgets_bokeh/src/widget.ts
@@ -4,9 +4,8 @@ import {UIElement} from "@bokehjs/models/ui/ui_element"
 import {Document} from "@bokehjs/document"
 import {MessageSentEvent} from "@bokehjs/document/events"
 import * as p from "@bokehjs/core/properties"
-import {isString, isObject} from "@bokehjs/core/util/types"
+import {isString} from "@bokehjs/core/util/types"
 import {assert} from "@bokehjs/core/util/assert"
-import {values} from "@bokehjs/core/util/object"
 
 import {generate_require_loader} from "./loader"
 import {WidgetManager, ModelBundle} from "./manager"
@@ -14,27 +13,6 @@ import {WidgetManager, ModelBundle} from "./manager"
 import {WidgetView} from "@jupyter-widgets/base"
 
 const widget_managers: WeakMap<Document, WidgetManager> = new WeakMap()
-
-declare type Module = {
-  id: string
-  loaded: boolean
-  exports: {[key: string]: unknown}
-}
-
-declare type UseOptions = {
-  handler?(css: string): void
-}
-
-declare type StyleModule = Module & {
-  exports: {
-    default: {
-      use(options?: UseOptions): void
-      unuse(): void
-    }
-  }
-}
-
-declare const __webpack_module_cache__: {[key: string]: Module}
 
 export class IPyWidgetView extends LayoutDOMView {
   container: HTMLDivElement
@@ -47,29 +25,32 @@ export class IPyWidgetView extends LayoutDOMView {
     return []
   }
 
+  override connect_signals(): void {
+    super.connect_signals()
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of [...mutation.addedNodes, ...mutation.removedNodes]) {
+          if (node instanceof HTMLStyleElement) {
+            this._update_stylesheets()
+            break
+          }
+        }
+      }
+    })
+    observer.observe(document.head, {childList: true})
+  }
+
   protected _ipy_stylesheets(): StyleSheetLike[] {
     const stylesheets: StyleSheetLike[] = []
 
-    function handler(raw_css: string): void {
-      const css = raw_css.replace(/:root/g, ":host")
-      stylesheets.push(new InlineStyleSheet(css))
-    }
-
-    function is_StyleModule(module: Module): module is StyleModule {
-      const {exports} = module
-      return isObject(exports.default) && "use" in exports.default
-    }
-
-    const modules = values(__webpack_module_cache__)
-    const css_modules = modules.filter(({id, exports}) => id.endsWith(".css") && "default" in exports)
-    const style_modules = css_modules.filter(is_StyleModule)
-
-    for (const module of style_modules) {
-      const style = module.exports.default
-      try {
-        style.use({handler})
-      } catch {
-        console.error("failed to apply a stylesheet")
+    for (const child of document.head.children) {
+      if (child instanceof HTMLStyleElement) {
+        const raw_css = child.textContent
+        if (raw_css != null) {
+          const css = raw_css.replace(/:root/g, ":host")
+          stylesheets.push(new InlineStyleSheet(css))
+        }
       }
     }
 
@@ -82,7 +63,7 @@ export class IPyWidgetView extends LayoutDOMView {
 
   override render(): void {
     super.render()
-    this.container = div({style: "display: contents;"})
+    this.container = div({style: "display: contents;"}) // ipywidgets' APIs require HTMLElement, not DocumentFragment
     this.shadow_el.append(this.container)
     this._render().then(() => {
       this.invalidate_layout() // TODO: this may be overzealous; probably should be removed

--- a/ipywidgets_bokeh/webpack.config.js
+++ b/ipywidgets_bokeh/webpack.config.js
@@ -1,19 +1,8 @@
 const path = require("path");
 const version = require('./package.json').version;
 
-const style_loader = {
-  loader: "style-loader",
-  options: {
-    injectType: "lazyStyleTag",
-    insert: (element, options) => {},
-    styleTagTransform: (css, style, options) => {
-      options.handler(css)
-    },
-  },
-}
-
 const rules = [
-  { test: /\.css$/, use: [style_loader, "css-loader"] },
+  { test: /\.css$/, use: ["style-loader", "css-loader"] },
   // required to load font-awesome
   { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: "url-loader?limit=10000&mimetype=application/font-woff" },
   { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: "url-loader?limit=10000&mimetype=application/font-woff" },


### PR DESCRIPTION
Instead of trying to be clever and working with `style-loader` and intercepting external bundles, observe the `<head>` and copy styles into ipywidgets' wrapper component. This may be overzealous in some rare cases, but works perfectly well in the majority. Thridparty components don't require special treatment. 

![image](https://user-images.githubusercontent.com/27475/235329060-d504142a-1960-4a85-9d01-b5a3700a5dbb.png)
