### PR TITLE
Handle comm_open messages containing new widget state

### DIFF
--- a/ipywidgets_bokeh/src/manager.ts
+++ b/ipywidgets_bokeh/src/manager.ts
@@ -128,8 +128,16 @@ export class WidgetManager extends HTMLManager {
     this.kernel = this.kernel_manager.connectTo({model: kernel_model, handleComms: true})
     this.kernel.registerCommTarget(this.comm_target_name, (comm, msg) => {
       const model = this._model_objs.get(msg.content.comm_id)
+      const comm_wrapper = new shims.services.Comm(comm)
+      if (model == null) {
+	this.handle_comm_open(comm_wrapper, msg).then((model) => {
+	  if (model != null && !model.comm_live) {
+            const comm_wrapper = new shims.services.Comm(comm)
+            this._attach_comm(comm_wrapper, model)
+	  }
+	})
+      }
       if (model != null && !model.comm_live) {
-        const comm_wrapper = new shims.services.Comm(comm)
         this._attach_comm(comm_wrapper, model)
       }
       this._model_objs.delete(msg.content.comm_id)


### PR DESCRIPTION
The way `ipywidgets` works when adding new models to an existing ipywidget is to send the widget state as part of the `comm_open` message that is sent on widget creation. To handle this correctly we now check whether a model already exists otherwise we pass the comm open message to the `handle_comm_open` handler on the `WidgetManager`.