### PR TITLE
Include all npm-generated files in the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include README.md
 include LICENSE.txt
 include ipywidgets_bokeh/bokeh.ext.json
 include ipywidgets_bokeh/package.json
-recursive-include ipywidgets_bokeh/dist *.js *.js.map *.d.ts *.json
+recursive-include ipywidgets_bokeh/dist *


### PR DESCRIPTION
Fixes issue #107

It seems the js packages that `ipywidgets_bokeh` uses need many static assets that were not included in the build package. As shown in the issue, the main symptom was 404 errors on the fonts. In this PR, I simply include all assets in the package. Maybe that's too much ? I guess at least the fonts should be included ?