### PR TITLE
fix: Remove LooseVersion

### DIFF
--- a/.github/workflows/ipywidgets-bokeh-ci.yml
+++ b/.github/workflows/ipywidgets-bokeh-ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [20.x]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
 
     defaults:
       run:

--- a/ipywidgets_bokeh/kernel.py
+++ b/ipywidgets_bokeh/kernel.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 import json
 import logging
 
-from distutils.version import LooseVersion
-
 import ipykernel
 import ipykernel.kernelbase
 import jupyter_client.session as session
@@ -19,8 +17,6 @@ from bokeh.document.events import MessageSentEvent
 from ipykernel.comm import CommManager
 from tornado.ioloop import IOLoop
 from traitlets import Any
-
-kernel_version = LooseVersion(ipykernel.__version__)
 
 SESSION_KEY = b'ipywidgets_bokeh'
 


### PR DESCRIPTION
Fixes https://github.com/bokeh/ipywidgets_bokeh/issues/109

`kernel_version` is no longer used, so we can remove the import of LooseVersion.