### PR TITLE
ci: Fix failing ci

### DIFF
--- a/.github/workflows/ipywidgets-bokeh-ci.yml
+++ b/.github/workflows/ipywidgets-bokeh-ci.yml
@@ -23,16 +23,17 @@ jobs:
 
     steps:
       - name: Set up conda and install base
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           activate-environment: test
+          channels: conda-forge
 
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/ipywidgets-bokeh-ci.yml
+++ b/.github/workflows/ipywidgets-bokeh-ci.yml
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [18.x]
+        node-version: [20.x]
         python-version: ["3.12"]
 
     defaults:

--- a/.github/workflows/ipywidgets-bokeh-ci.yml
+++ b/.github/workflows/ipywidgets-bokeh-ci.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [18.x]
+        python-version: ["3.12"]
 
     defaults:
       run:
@@ -66,7 +67,7 @@ jobs:
       - name: Install dev Python dependencies & Playwright browsers
         if: success() || failure()
         run: |
-          conda install --channel conda-forge -y pip python
+          conda install -y pip python=${{ matrix.python-version }}
           conda info
           python -m pip install --editable .[dev]
           python -m playwright install --with-deps

--- a/.github/workflows/ipywidgets-bokeh-ci.yml
+++ b/.github/workflows/ipywidgets-bokeh-ci.yml
@@ -70,10 +70,9 @@ jobs:
           conda install -y pip python=${{ matrix.python-version }}
           conda info
           python -m pip install --editable .[dev]
-          python -m playwright install --with-deps
+          python -m playwright install chromium
 
       - name: Run Playwright & Python tests
-        if: matrix.os != 'windows-latest'
         run: |
           pytest
 

--- a/.github/workflows/ipywidgets-bokeh-ci.yml
+++ b/.github/workflows/ipywidgets-bokeh-ci.yml
@@ -29,6 +29,7 @@ jobs:
           auto-update-conda: true
           activate-environment: test
           channels: conda-forge
+          python-version: ${{ matrix.python-version }}
 
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -67,7 +68,6 @@ jobs:
       - name: Install dev Python dependencies & Playwright browsers
         if: success() || failure()
         run: |
-          conda install -y pip python=${{ matrix.python-version }}
           conda info
           python -m pip install --editable .[dev]
           python -m playwright install chromium

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import asyncio
+
+import pytest
+from panel.tests.conftest import server_cleanup  # noqa: F401
+
+
+@pytest.fixture
+def asyncio_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    yield
+    loop.stop()
+    loop.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,1 @@
-import asyncio
-
-import pytest
-from panel.tests.conftest import server_cleanup  # noqa: F401
-
-
-@pytest.fixture
-def asyncio_loop():
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(asyncio.new_event_loop())
-    yield
-    loop.stop()
-    loop.close()
+from panel.tests.conftest import asyncio_loop, server_cleanup  # noqa: F401

--- a/tests/test_anywidget.py
+++ b/tests/test_anywidget.py
@@ -1,10 +1,8 @@
-import time
-
 import anywidget
 import panel as pn
 import traitlets
-from panel.io.server import serve
-from playwright.sync_api import expect, Page
+from panel.tests.util import serve_and_wait
+from playwright.sync_api import Page, expect
 
 
 class CounterWidget(anywidget.AnyWidget):
@@ -33,7 +31,7 @@ class CounterWidget(anywidget.AnyWidget):
     count = traitlets.Int(default_value=0).tag(sync=True)
 
 
-def test_anywidget(page: Page) -> None:
+def test_anywidget(page: Page, asyncio_loop) -> None:
     """Test anywidget button counter example."""
     # Port to run the panel server on.
     port = 5006
@@ -44,8 +42,7 @@ def test_anywidget(page: Page) -> None:
 
     # Serve the button using panel, the time delay is necessary for panel to start and
     # serve the widget.
-    serve(panels=panels, port=port, show=False)
-    time.sleep(0.2)
+    serve_and_wait(panels, port=port)
 
     # Go to the page and locate the widget using playwright.
     page.goto(f"http://localhost:{port}")


### PR DESCRIPTION
- Bumping Github actions
- Using some of Panel's test utils.
- Pinning to Python 3.12 because of #115 
- Bumping Node version to 20.x