### PR TITLE
Add release automation

### DIFF
--- a/.github/workflows/ipywidgets-bokeh-ci.yml
+++ b/.github/workflows/ipywidgets-bokeh-ci.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
+      - name: Check release version consistency
+        run: |
+          python scripts/release.py check
+
       - name: Install node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -80,4 +84,4 @@ jobs:
         if: success() || failure()
         run: |
           OUTPUT=$(git status --short .)
-          if [[ ! -z "$OUTPUT" ]]; then echo $OUTPUT; exit 1; fi
+          if [[ -n "$OUTPUT" ]]; then echo "$OUTPUT"; exit 1; fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,266 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and verify release artifacts
+    runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.version.outputs.prerelease }}
+
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - name: Checkout the tagged source
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up release build environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: release-build
+          channels: conda-forge
+          conda-build-version: "*"
+          miniforge-version: latest
+          python-version: "3.13"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Validate tag and version metadata
+        id: version
+        run: |
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          python scripts/release.py check --tag "$GITHUB_REF_NAME"
+          echo "prerelease=$(python scripts/release.py show prerelease)" >> "$GITHUB_OUTPUT"
+
+      - name: Install release build tools
+        run: |
+          python -m pip install --disable-pip-version-check build twine
+
+      - name: Build JavaScript and npm package
+        working-directory: ipywidgets_bokeh
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+          mkdir -p ../release-artifacts/npm
+          npm pack --ignore-scripts --pack-destination ../release-artifacts/npm
+
+      - name: Build Python distributions
+        run: |
+          python -m build --outdir release-artifacts/python
+          python -m twine check release-artifacts/python/*
+
+      - name: Build and test conda package
+        run: |
+          conda build conda.recipe \
+            --no-anaconda-upload \
+            --output-folder release-artifacts/conda
+
+      - name: Verify release artifacts
+        run: |
+          python scripts/release.py verify-artifacts release-artifacts \
+            --checksums release-artifacts/SHA256SUMS
+
+      - name: Upload Python distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-distributions
+          path: release-artifacts/python/*
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload npm package
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-package
+          path: release-artifacts/npm/*.tgz
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload conda package
+        uses: actions/upload-artifact@v4
+        with:
+          name: conda-package
+          path: |
+            release-artifacts/conda/**/*.conda
+            release-artifacts/conda/**/*.tar.bz2
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload checksums
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-checksums
+          path: release-artifacts/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 30
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-distributions
+          path: dist
+
+      - name: Publish Python distributions
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+
+  publish-npm:
+    name: Publish to npm
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Set up Node.js for trusted publishing
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+
+      - name: Download npm package
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-package
+          path: dist
+
+      - name: Publish npm package
+        env:
+          PRERELEASE: ${{ needs.build.outputs.prerelease }}
+        run: |
+          args=(--access public)
+          if [[ "$PRERELEASE" == "true" ]]; then
+            args+=(--tag next)
+          fi
+          npm publish dist/*.tgz "${args[@]}"
+
+  publish-conda:
+    name: Publish to Anaconda.org
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - name: Set up Anaconda client
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: release-publish
+          channels: conda-forge
+          miniforge-version: latest
+          python-version: "3.13"
+
+      - name: Install Anaconda client
+        run: conda install --yes anaconda-client
+
+      - name: Download conda package
+        uses: actions/download-artifact@v4
+        with:
+          name: conda-package
+          path: dist
+
+      - name: Publish conda package
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+          PRERELEASE: ${{ needs.build.outputs.prerelease }}
+        run: |
+          if [[ -z "$ANACONDA_API_TOKEN" ]]; then
+            echo "ANACONDA_API_TOKEN is not configured in the release environment" >&2
+            exit 1
+          fi
+          mapfile -t packages < <(find dist -type f \( -name '*.conda' -o -name '*.tar.bz2' \))
+          if [[ ${#packages[@]} -ne 1 ]]; then
+            echo "expected one conda package, found ${#packages[@]}" >&2
+            exit 1
+          fi
+          labels=(--label dev)
+          if [[ "$PRERELEASE" != "true" ]]; then
+            labels+=(--label main)
+          fi
+          anaconda --token "$ANACONDA_API_TOKEN" upload \
+            --user bokeh \
+            "${labels[@]}" \
+            "${packages[0]}"
+
+  github-release:
+    name: Create GitHub Release
+    needs: [build, publish-pypi, publish-npm, publish-conda]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-distributions
+          path: artifacts/python
+
+      - name: Download npm package
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-package
+          path: artifacts/npm
+
+      - name: Download conda package
+        uses: actions/download-artifact@v4
+        with:
+          name: conda-package
+          path: artifacts/conda
+
+      - name: Download checksums
+        uses: actions/download-artifact@v4
+        with:
+          name: release-checksums
+          path: artifacts/checksums
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ needs.build.outputs.prerelease }}
+        run: |
+          args=(--verify-tag --generate-notes --title "$GITHUB_REF_NAME")
+          if [[ "$PRERELEASE" == "true" ]]; then
+            args+=(--prerelease)
+          fi
+          mapfile -t assets < <(find artifacts -type f)
+          gh release create "$GITHUB_REF_NAME" "${assets[@]}" "${args[@]}"

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -1,10 +1,49 @@
-# Release process
+# Development guide
 
-## Update package version
+## Release process
 
-| File                            | Entry                    | Content        |
-| ------------------------------- | ------------------------ | -------------- |
-| `ipywidgets_bokeh/__init__.py`  | `__version__`            | `1.0.0dev2`    |
-| `ipywidgets_bokeh/kernel.py`    | `implementation_version` | `1.0.0dev2`    |
-| `ipywidgets_bokeh/package.json` | `version`                | `1.0.0-dev.2`  |
-| `setup.py`                      | `version`                | `1.0.0dev2`    |
+Releases are built and published by `.github/workflows/release.yml`. The workflow is triggered by a version tag such as `1.8.0`; the tagged commit must be on `main`, and the tag must exactly match the Python package version.
+
+### One-time repository and registry configuration
+
+Create a GitHub environment named `release` and configure required reviewers. Restrict the environment to protected version tags, and protect version tags so only release maintainers can create them.
+
+Configure both trusted publishers with the GitHub owner `bokeh`, repository `ipywidgets_bokeh`, workflow `release.yml`, and environment `release`:
+
+- On PyPI, configure the trusted publisher for the `ipywidgets_bokeh` project.
+- On npm, configure the trusted publisher for `@bokeh/ipywidgets_bokeh` and allow `npm publish`.
+
+Add an environment secret named `ANACONDA_API_TOKEN` to `release`. Use a token scoped to upload packages to the `bokeh` Anaconda.org channel; do not make it a repository-wide secret.
+
+PyPI and npm use short-lived GitHub OIDC credentials and do not require stored API tokens. The conda upload is the only publishing job that receives `ANACONDA_API_TOKEN`.
+
+### Prepare a release
+
+From a clean checkout of `main`, choose the version and update every Python and npm version field together:
+
+```bash
+python scripts/release.py prepare 1.8.0
+python scripts/release.py check
+```
+
+Commit the version change through the normal pull request process. After that commit is merged and CI succeeds on `main`, create and push the matching tag:
+
+```bash
+git tag 1.8.0
+git push origin 1.8.0
+```
+
+The `release` environment approval gates publication. The workflow builds and verifies the Python, npm, and conda artifacts once, publishes those exact artifacts to all three registries, and creates a GitHub Release with the artifacts and SHA-256 checksums only after every registry publication succeeds.
+
+For a prerelease, use the Python version form as the tag and preparation input. The preparation script maps it to npm SemVer automatically, for example:
+
+| Python and tag | npm |
+| -------------- | --- |
+| `2.0.0.dev1` | `2.0.0-dev.1` |
+| `2.0.0a1` | `2.0.0-alpha.1` |
+| `2.0.0b1` | `2.0.0-beta.1` |
+| `2.0.0rc1` | `2.0.0-rc.1` |
+
+Prereleases are marked as such on GitHub, use the npm `next` distribution tag, and are uploaded only to the Anaconda.org `dev` label. Stable releases are uploaded to both the `dev` and `main` Anaconda.org labels.
+
+If a publishing job fails after another registry has accepted the release, use **Re-run failed jobs** in GitHub Actions. Do not create a second tag or rebuild artifacts manually.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include README.md
 include LICENSE.txt
 include ipywidgets_bokeh/bokeh.ext.json
 include ipywidgets_bokeh/package.json
+include ipywidgets_bokeh/package-lock.json
 recursive-include ipywidgets_bokeh/dist *

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   build:
     - python >=3.9
     - setuptools
-    - nodejs 18.*
+    - nodejs 20.*
   run:
     - python >=3.9
     - bokeh 3.* # TODO 3.2.dev1

--- a/ipywidgets_bokeh/__init__.py
+++ b/ipywidgets_bokeh/__init__.py
@@ -1,3 +1,3 @@
 from .widget import IPyWidget
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"

--- a/ipywidgets_bokeh/kernel.py
+++ b/ipywidgets_bokeh/kernel.py
@@ -103,7 +103,7 @@ class ShellStream:
 
 class BokehKernel(ipykernel.kernelbase.Kernel):
     implementation = 'ipython'
-    implementation_version = '1.7.0'
+    implementation_version = '1.8.0'
     banner = 'banner'
 
     shell_stream = Any(ShellStream(), allow_none=True)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,8 +3,10 @@
 set -e
 set -x
 
+python scripts/release.py check
+
 cd ipywidgets_bokeh/
-npm install
+npm ci
 npm run build
 cd ..
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -69,7 +69,7 @@ def parse_version(value: str) -> Version:
 
 def _read_pattern(root: Path, relative_path: str, pattern: re.Pattern[str]) -> str:
     path = root / relative_path
-    matches = pattern.findall(path.read_text())
+    matches = pattern.findall(path.read_text(encoding="utf-8"))
     if len(matches) != 1:
         raise ReleaseError(f"expected exactly one version field in {relative_path}, found {len(matches)}")
     return matches[0]
@@ -81,8 +81,8 @@ def read_versions(root: Path = ROOT) -> dict[str, str]:
         for relative_path, pattern in VERSION_PATTERNS.items()
     }
 
-    package_json = json.loads((root / "ipywidgets_bokeh/package.json").read_text())
-    package_lock = json.loads((root / "ipywidgets_bokeh/package-lock.json").read_text())
+    package_json = json.loads((root / "ipywidgets_bokeh/package.json").read_text(encoding="utf-8"))
+    package_lock = json.loads((root / "ipywidgets_bokeh/package-lock.json").read_text(encoding="utf-8"))
     try:
         versions["ipywidgets_bokeh/package.json"] = package_json["version"]
         versions["ipywidgets_bokeh/package-lock.json"] = package_lock["version"]
@@ -118,7 +118,7 @@ def check_versions(root: Path = ROOT, tag: str | None = None) -> Version:
 
 def _replace_pattern(root: Path, relative_path: str, pattern: re.Pattern[str], version: str) -> str:
     path = root / relative_path
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     updated, count = pattern.subn(lambda match: match.group(0).replace(match.group(1), version), text)
     if count != 1:
         raise ReleaseError(f"expected exactly one version field in {relative_path}, found {count}")
@@ -132,12 +132,12 @@ def prepare_version(version_value: str, root: Path = ROOT) -> Version:
         updates[root / relative_path] = _replace_pattern(root, relative_path, pattern, version.python)
 
     package_path = root / "ipywidgets_bokeh/package.json"
-    package_json = json.loads(package_path.read_text())
+    package_json = json.loads(package_path.read_text(encoding="utf-8"))
     package_json["version"] = version.npm
     updates[package_path] = json.dumps(package_json, indent=2) + "\n"
 
     lock_path = root / "ipywidgets_bokeh/package-lock.json"
-    package_lock = json.loads(lock_path.read_text())
+    package_lock = json.loads(lock_path.read_text(encoding="utf-8"))
     try:
         package_lock["version"] = version.npm
         package_lock["packages"][""]["version"] = version.npm
@@ -146,7 +146,7 @@ def prepare_version(version_value: str, root: Path = ROOT) -> Version:
     updates[lock_path] = json.dumps(package_lock, indent=2) + "\n"
 
     for path, content in updates.items():
-        path.write_text(content)
+        path.write_text(content, encoding="utf-8")
 
     return check_versions(root)
 
@@ -248,7 +248,7 @@ def _verify_conda(path: Path, version: Version) -> None:
         index_path = destination / "info/index.json"
         if not index_path.exists():
             raise ReleaseError(f"{path.name} does not contain info/index.json")
-        index = json.loads(index_path.read_text())
+        index = json.loads(index_path.read_text(encoding="utf-8"))
         if index.get("name") != "ipywidgets_bokeh" or index.get("version") != version.python:
             raise ReleaseError(f"{path.name} has incorrect conda package metadata")
         bundle = list(destination.glob("**/site-packages/ipywidgets_bokeh/dist/ipywidgets_bokeh.js"))
@@ -275,7 +275,7 @@ def verify_artifacts(artifacts: Path, version: Version, checksums: Path | None =
         for path in sorted(distributions, key=lambda item: item.name):
             digest = hashlib.sha256(path.read_bytes()).hexdigest()
             lines.append(f"{digest}  {path.name}")
-        checksums.write_text("\n".join(lines) + "\n")
+        checksums.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PYTHON_VERSION_RE = re.compile(
+    r"^(?P<release>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))"
+    r"(?:(?P<pre>a|b|rc)(?P<pre_number>0|[1-9]\d*))?"
+    r"(?:\.dev(?P<dev_number>0|[1-9]\d*))?$"
+)
+
+VERSION_PATTERNS = {
+    "setup.py": re.compile(r'^    version="([^"]+)",$', re.MULTILINE),
+    "ipywidgets_bokeh/__init__.py": re.compile(r'^__version__ = "([^"]+)"$', re.MULTILINE),
+    "ipywidgets_bokeh/kernel.py": re.compile(r"^    implementation_version = '([^']+)'$", re.MULTILINE),
+}
+
+
+class ReleaseError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Version:
+    python: str
+    npm: str
+    prerelease: bool
+
+
+def parse_version(value: str) -> Version:
+    match = PYTHON_VERSION_RE.fullmatch(value)
+    if match is None:
+        raise ReleaseError(
+            f"invalid release version {value!r}; expected X.Y.Z with an optional "
+            "aN, bN, rcN, and/or .devN suffix"
+        )
+
+    suffix = []
+    pre = match.group("pre")
+    if pre is not None:
+        suffix.append({"a": "alpha", "b": "beta", "rc": "rc"}[pre])
+        suffix.append(match.group("pre_number"))
+
+    dev_number = match.group("dev_number")
+    if pre is not None and dev_number is not None:
+        raise ReleaseError("combined prerelease and development suffixes are not supported")
+    if dev_number is not None:
+        suffix.extend(("dev", dev_number))
+
+    npm = match.group("release")
+    if suffix:
+        npm += "-" + ".".join(suffix)
+
+    return Version(python=value, npm=npm, prerelease=bool(suffix))
+
+
+def _read_pattern(root: Path, relative_path: str, pattern: re.Pattern[str]) -> str:
+    path = root / relative_path
+    matches = pattern.findall(path.read_text())
+    if len(matches) != 1:
+        raise ReleaseError(f"expected exactly one version field in {relative_path}, found {len(matches)}")
+    return matches[0]
+
+
+def read_versions(root: Path = ROOT) -> dict[str, str]:
+    versions = {
+        relative_path: _read_pattern(root, relative_path, pattern)
+        for relative_path, pattern in VERSION_PATTERNS.items()
+    }
+
+    package_json = json.loads((root / "ipywidgets_bokeh/package.json").read_text())
+    package_lock = json.loads((root / "ipywidgets_bokeh/package-lock.json").read_text())
+    try:
+        versions["ipywidgets_bokeh/package.json"] = package_json["version"]
+        versions["ipywidgets_bokeh/package-lock.json"] = package_lock["version"]
+        versions['ipywidgets_bokeh/package-lock.json packages[""]'] = package_lock["packages"][""]["version"]
+    except (KeyError, TypeError) as error:
+        raise ReleaseError(f"missing npm version metadata: {error}") from error
+
+    return versions
+
+
+def check_versions(root: Path = ROOT, tag: str | None = None) -> Version:
+    versions = read_versions(root)
+    version = parse_version(versions["setup.py"])
+    expected = {
+        "setup.py": version.python,
+        "ipywidgets_bokeh/__init__.py": version.python,
+        "ipywidgets_bokeh/kernel.py": version.python,
+        "ipywidgets_bokeh/package.json": version.npm,
+        "ipywidgets_bokeh/package-lock.json": version.npm,
+        'ipywidgets_bokeh/package-lock.json packages[""]': version.npm,
+    }
+    mismatches = [
+        f"{location}: expected {expected_value!r}, found {versions[location]!r}"
+        for location, expected_value in expected.items()
+        if versions[location] != expected_value
+    ]
+    if tag is not None and tag != version.python:
+        mismatches.append(f"release tag: expected {version.python!r}, found {tag!r}")
+    if mismatches:
+        raise ReleaseError("inconsistent release versions:\n  - " + "\n  - ".join(mismatches))
+    return version
+
+
+def _replace_pattern(root: Path, relative_path: str, pattern: re.Pattern[str], version: str) -> str:
+    path = root / relative_path
+    text = path.read_text()
+    updated, count = pattern.subn(lambda match: match.group(0).replace(match.group(1), version), text)
+    if count != 1:
+        raise ReleaseError(f"expected exactly one version field in {relative_path}, found {count}")
+    return updated
+
+
+def prepare_version(version_value: str, root: Path = ROOT) -> Version:
+    version = parse_version(version_value)
+    updates = {}
+    for relative_path, pattern in VERSION_PATTERNS.items():
+        updates[root / relative_path] = _replace_pattern(root, relative_path, pattern, version.python)
+
+    package_path = root / "ipywidgets_bokeh/package.json"
+    package_json = json.loads(package_path.read_text())
+    package_json["version"] = version.npm
+    updates[package_path] = json.dumps(package_json, indent=2) + "\n"
+
+    lock_path = root / "ipywidgets_bokeh/package-lock.json"
+    package_lock = json.loads(lock_path.read_text())
+    try:
+        package_lock["version"] = version.npm
+        package_lock["packages"][""]["version"] = version.npm
+    except (KeyError, TypeError) as error:
+        raise ReleaseError(f"missing npm version metadata: {error}") from error
+    updates[lock_path] = json.dumps(package_lock, indent=2) + "\n"
+
+    for path, content in updates.items():
+        path.write_text(content)
+
+    return check_versions(root)
+
+
+def _expect_one(paths: list[Path], description: str) -> Path:
+    if len(paths) != 1:
+        found = ", ".join(str(path) for path in paths) or "none"
+        raise ReleaseError(f"expected exactly one {description}, found: {found}")
+    return paths[0]
+
+
+def _metadata_version(metadata: str) -> str:
+    match = re.search(r"^Version: (.+)$", metadata, re.MULTILINE)
+    if match is None:
+        raise ReleaseError("package metadata does not contain a Version field")
+    return match.group(1).strip()
+
+
+def _check_python_sources(names: set[str], read_text, version: str, source: str) -> None:
+    init_path = _expect_one(
+        [Path(name) for name in names if name.endswith("ipywidgets_bokeh/__init__.py")],
+        f"{source} __init__.py",
+    )
+    kernel_path = _expect_one(
+        [Path(name) for name in names if name.endswith("ipywidgets_bokeh/kernel.py")],
+        f"{source} kernel.py",
+    )
+    if f'__version__ = "{version}"' not in read_text(str(init_path)):
+        raise ReleaseError(f"{source} contains an incorrect runtime __version__")
+    if f"implementation_version = '{version}'" not in read_text(str(kernel_path)):
+        raise ReleaseError(f"{source} contains an incorrect kernel implementation_version")
+    if not any(name.endswith("ipywidgets_bokeh/dist/ipywidgets_bokeh.js") for name in names):
+        raise ReleaseError(f"{source} does not contain the built JavaScript bundle")
+
+
+def _verify_wheel(path: Path, version: Version) -> None:
+    with zipfile.ZipFile(path) as archive:
+        names = set(archive.namelist())
+        metadata_path = _expect_one(
+            [Path(name) for name in names if name.endswith(".dist-info/METADATA")],
+            "wheel METADATA",
+        )
+        metadata = archive.read(str(metadata_path)).decode()
+        if _metadata_version(metadata) != version.python:
+            raise ReleaseError(f"{path.name} metadata version does not match {version.python}")
+        _check_python_sources(names, lambda name: archive.read(name).decode(), version.python, path.name)
+
+
+def _verify_sdist(path: Path, version: Version) -> None:
+    with tarfile.open(path) as archive:
+        names = set(archive.getnames())
+        metadata_path = _expect_one(
+            [Path(name) for name in names if name.count("/") == 1 and name.endswith("/PKG-INFO")],
+            "sdist PKG-INFO",
+        )
+        metadata_file = archive.extractfile(str(metadata_path))
+        if metadata_file is None:
+            raise ReleaseError(f"cannot read metadata from {path.name}")
+        if _metadata_version(metadata_file.read().decode()) != version.python:
+            raise ReleaseError(f"{path.name} metadata version does not match {version.python}")
+
+        def read_text(name: str) -> str:
+            member = archive.extractfile(name)
+            if member is None:
+                raise ReleaseError(f"cannot read {name} from {path.name}")
+            return member.read().decode()
+
+        _check_python_sources(names, read_text, version.python, path.name)
+
+
+def _verify_npm(path: Path, version: Version) -> None:
+    with tarfile.open(path) as archive:
+        names = set(archive.getnames())
+        if "package/package.json" not in names:
+            raise ReleaseError(f"{path.name} does not contain package/package.json")
+        package_file = archive.extractfile("package/package.json")
+        if package_file is None:
+            raise ReleaseError(f"cannot read package.json from {path.name}")
+        package = json.loads(package_file.read())
+        if package.get("name") != "@bokeh/ipywidgets_bokeh" or package.get("version") != version.npm:
+            raise ReleaseError(f"{path.name} has incorrect npm package metadata")
+        if "package/dist/ipywidgets_bokeh.js" not in names:
+            raise ReleaseError(f"{path.name} does not contain the built JavaScript bundle")
+
+
+def _verify_conda(path: Path, version: Version) -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        destination = Path(temp_dir)
+        if path.name.endswith(".tar.bz2"):
+            with tarfile.open(path) as archive:
+                archive.extractall(destination, filter="data")
+        else:
+            try:
+                from conda_package_handling.api import extract
+            except ImportError as error:
+                raise ReleaseError("conda-package-handling is required to verify .conda artifacts") from error
+            extract(str(path), dest_dir=str(destination))
+
+        index_path = destination / "info/index.json"
+        if not index_path.exists():
+            raise ReleaseError(f"{path.name} does not contain info/index.json")
+        index = json.loads(index_path.read_text())
+        if index.get("name") != "ipywidgets_bokeh" or index.get("version") != version.python:
+            raise ReleaseError(f"{path.name} has incorrect conda package metadata")
+        bundle = list(destination.glob("**/site-packages/ipywidgets_bokeh/dist/ipywidgets_bokeh.js"))
+        if len(bundle) != 1:
+            raise ReleaseError(f"{path.name} does not contain exactly one built JavaScript bundle")
+
+
+def verify_artifacts(artifacts: Path, version: Version, checksums: Path | None = None) -> None:
+    wheel = _expect_one(list((artifacts / "python").glob("*.whl")), "wheel")
+    sdist = _expect_one(list((artifacts / "python").glob("*.tar.gz")), "source distribution")
+    npm = _expect_one(list((artifacts / "npm").glob("*.tgz")), "npm package")
+    conda_candidates = list((artifacts / "conda").glob("**/*.conda"))
+    conda_candidates += list((artifacts / "conda").glob("**/*.tar.bz2"))
+    conda = _expect_one(conda_candidates, "conda package")
+
+    _verify_wheel(wheel, version)
+    _verify_sdist(sdist, version)
+    _verify_npm(npm, version)
+    _verify_conda(conda, version)
+
+    distributions = (wheel, sdist, npm, conda)
+    if checksums is not None:
+        lines = []
+        for path in sorted(distributions, key=lambda item: item.name):
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            lines.append(f"{digest}  {path.name}")
+        checksums.write_text("\n".join(lines) + "\n")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare and validate ipywidgets_bokeh releases")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    check = commands.add_parser("check", help="check version consistency")
+    check.add_argument("--tag", help="also require the release tag to match")
+
+    prepare = commands.add_parser("prepare", help="update all release version fields")
+    prepare.add_argument("version")
+
+    show = commands.add_parser("show", help="print normalized release metadata")
+    show.add_argument("field", choices=("python", "npm", "prerelease"))
+
+    verify = commands.add_parser("verify-artifacts", help="validate built release artifacts")
+    verify.add_argument("directory", type=Path)
+    verify.add_argument("--checksums", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "prepare":
+            version = prepare_version(args.version)
+            print(f"prepared Python {version.python} / npm {version.npm}")
+        elif args.command == "check":
+            version = check_versions(tag=args.tag)
+            print(f"versions are consistent: Python {version.python} / npm {version.npm}")
+        elif args.command == "show":
+            version = check_versions()
+            value = getattr(version, args.field)
+            print(str(value).lower() if isinstance(value, bool) else value)
+        elif args.command == "verify-artifacts":
+            version = check_versions()
+            verify_artifacts(args.directory, version, args.checksums)
+            print(f"release artifacts are valid for {version.python}")
+    except (OSError, ReleaseError, tarfile.TarError, zipfile.BadZipFile, json.JSONDecodeError) as error:
+        print(f"release error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+import release  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("python_version", "npm_version", "prerelease"),
+    [
+        ("1.8.0", "1.8.0", False),
+        ("1.8.0.dev1", "1.8.0-dev.1", True),
+        ("1.8.0a2", "1.8.0-alpha.2", True),
+        ("1.8.0b3", "1.8.0-beta.3", True),
+        ("1.8.0rc4", "1.8.0-rc.4", True),
+    ],
+)
+def test_parse_version(python_version, npm_version, prerelease):
+    version = release.parse_version(python_version)
+    assert version.python == python_version
+    assert version.npm == npm_version
+    assert version.prerelease is prerelease
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["1.8", "v1.8.0", "1.8.0-dev.1", "1.8.0.post1", "1.8.0rc1.dev1", "01.8.0"],
+)
+def test_parse_version_rejects_unsupported_versions(version):
+    with pytest.raises(release.ReleaseError):
+        release.parse_version(version)
+
+
+def test_repository_versions_are_consistent():
+    release.check_versions(ROOT)
+
+
+def test_prepare_version_updates_all_metadata(tmp_path):
+    paths = [*release.VERSION_PATTERNS, "ipywidgets_bokeh/package.json", "ipywidgets_bokeh/package-lock.json"]
+    for relative_path in paths:
+        destination = tmp_path / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(ROOT / relative_path, destination)
+
+    version = release.prepare_version("2.0.0rc1", tmp_path)
+
+    assert version.python == "2.0.0rc1"
+    assert version.npm == "2.0.0-rc.1"
+    assert set(release.read_versions(tmp_path).values()) == {version.python, version.npm}

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -42,6 +42,17 @@ def test_repository_versions_are_consistent():
     release.check_versions(ROOT)
 
 
+def test_read_versions_uses_utf8(monkeypatch):
+    original_read_text = Path.read_text
+
+    def read_text(path, *args, **kwargs):
+        assert kwargs.get("encoding") == "utf-8"
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+    release.read_versions(ROOT)
+
+
 def test_prepare_version_updates_all_metadata(tmp_path):
     paths = [*release.VERSION_PATTERNS, "ipywidgets_bokeh/package.json", "ipywidgets_bokeh/package-lock.json"]
     for relative_path in paths:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages, Command
 
 class BuildJS(Command):
 
-    description = "runs 'npm install && npm run prepack'"
+    description = "runs 'npm ci && npm run prepack'"
     user_options = []
 
     def initialize_options(self):
@@ -19,7 +19,7 @@ class BuildJS(Command):
         npm = "npm" if sys.platform != "win32" else "npm.bat"
         os.chdir("ipywidgets_bokeh")
         try:
-            self.spawn([npm, "install"])
+            self.spawn([npm, "ci"])
             self.spawn([npm, "run", "prepack"])
         finally:
             os.chdir("..")


### PR DESCRIPTION
[codex]

@philippjfr I have not looked at this in the slightest yet. It's easier for me to evaluate the diffs on GH, so I went ahead and pushed this PR to look over later today/tomorrow. But if you have any thoughts about the shape of this automation please chime in. 

Edit: 

If we go with this, noting required repo config:

### Required one-time release configuration

> 
> This PR adds the release workflow, but its repository and registry trust settings must be configured separately. After merging this PR—and before pushing the first release tag—a repository administrator should:
> 
> - Create a GitHub environment named `release`:
>   - Require approval from release maintainers.
>   - Preferably prevent self-review.
>   - Restrict deployments to release tags such as `*.*.*`.
>   - Add the environment secret `ANACONDA_API_TOKEN`, scoped for uploads to the `bokeh` Anaconda channel.
> - Add an active GitHub tag ruleset for release tags, restricting tag creation, modification, and deletion to release maintainers.
> - Configure PyPI Trusted Publishing for `ipywidgets_bokeh`:
>   - Owner: `bokeh`
>   - Repository: `ipywidgets_bokeh`
>   - Workflow: `release.yml`
>   - Environment: `release`
> - Configure npm Trusted Publishing for `@bokeh/ipywidgets_bokeh` using the same repository, workflow, and environment, with `npm publish` explicitly allowed.
> 
> The repository’s read-only default Actions permission can remain unchanged. PyPI and npm use OIDC, so no long-lived PyPI or npm tokens should be added to GitHub.
> 
> Do not push a release tag until all configuration above is complete, since registry publication is not transactional.