### PR TITLE
Add missing checkout step to github-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,9 @@ jobs:
       actions: read
 
     steps:
+      - name: Checkout the tagged source
+        uses: actions/checkout@v6
+
       - name: Download Python distributions
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- `gh release create --verify-tag` requires a local git checkout to verify the tag against, but the `github-release` job never checked out the repo, so it fails with `fatal: not a git repository`.
- Adds an `actions/checkout` step before the release-creation step, matching what was tested when finishing the 1.8.0 release.

## Test plan
- [ ] Re-run/dispatch the release workflow with `reuse_run_id` for 1.8.0 and confirm `github-release` succeeds.